### PR TITLE
Add blog categories table to config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "optimistdigital/nova-blog",
+  "name": "sidorenkoda/nova-blog",
   "description": "Blog manager for Laravel Nova",
   "keywords": [
     "laravel",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sidorenkoda/nova-blog",
+  "name": "optimistdigital/nova-blog",
   "description": "Blog manager for Laravel Nova",
   "keywords": [
     "laravel",

--- a/config/nova-blog.php
+++ b/config/nova-blog.php
@@ -12,6 +12,7 @@ return [
   */
 
   'table' => 'nova_blog_posts',
+  'table_categories' => 'nova_blog_categories',
 
   /*
   |--------------------------------------------------------------------------

--- a/database/migrations/2019_06_18_000000_create_nova_blog_posts_table.php
+++ b/database/migrations/2019_06_18_000000_create_nova_blog_posts_table.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateBlogPostsTable extends Migration
+class CreateNovaBlogPostsTable extends Migration
 {
     /**
      * Run the migrations.

--- a/database/migrations/2019_08_14_121846_create_categories_table.php
+++ b/database/migrations/2019_08_14_121846_create_categories_table.php
@@ -13,7 +13,8 @@ class CreateCategoriesTable extends Migration
      */
     public function up()
     {
-        Schema::create('categories', function (Blueprint $table) {
+        $table = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::create($table, function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->timestamps();
             $table->string('title');
@@ -27,6 +28,7 @@ class CreateCategoriesTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('categories');
+        $table = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::dropIfExists($table);
     }
 }

--- a/database/migrations/2019_08_14_130350_add_category_to_nova_blog_posts.php
+++ b/database/migrations/2019_08_14_130350_add_category_to_nova_blog_posts.php
@@ -16,8 +16,9 @@ class AddCategoryToNovaBlogPosts extends Migration
         $table = config('nova-blog.table', 'nova_blog_posts');
 
         Schema::table($table, function (Blueprint $table) {
+            $tableCategories = config('nova-blog.table_categories', 'nova_blog_categories');
             $table->bigInteger('category_id')->unsigned()->nullable();
-            $table->foreign('category_id')->references('id')->on('categories');
+            $table->foreign('category_id')->references('id')->on($tableCategories);
         });
     }
 
@@ -28,7 +29,8 @@ class AddCategoryToNovaBlogPosts extends Migration
      */
     public function down()
     {
-        Schema::table('nova_blog_posts', function (Blueprint $table) {
+        $table = config('nova-blog.table', 'nova_blog_posts');
+        Schema::table($table, function (Blueprint $table) {
             //
         });
     }

--- a/database/migrations/2019_09_12_161000_add_slug_to_category.php
+++ b/database/migrations/2019_09_12_161000_add_slug_to_category.php
@@ -13,7 +13,8 @@ class AddSlugToCategory extends Migration
      */
     public function up()
     {
-        Schema::table('categories', function (Blueprint $table) {
+        $table = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($table, function (Blueprint $table) {
             $table->string('slug')->default('');
         });
     }

--- a/database/migrations/2019_10_04_160450_add_seo_fileds_to_nova_blog_category.php
+++ b/database/migrations/2019_10_04_160450_add_seo_fileds_to_nova_blog_category.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSeoFiledsToNovaBlogCategory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $table = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($table, function (Blueprint $table) {
+            $table->string('seo_title')->nullable();
+            $table->string('seo_description')->nullable();
+            $table->string('seo_image')->nullable();
+            $table->string('category_introduction')->nullable();
+            $table->string('category_content')->nullable();
+            $table->integer('sort')->unsigned()->default(0)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableCategory = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($tableCategory, function (Blueprint $table) {
+            $table->dropColumn('seo_title');
+            $table->dropColumn('seo_description');
+            $table->dropColumn('seo_image');
+            $table->dropColumn('category_introduction');
+            $table->dropColumn('category_content');
+            $table->dropColumn('sort');
+        });
+    }
+}

--- a/database/migrations/2019_10_04_163805_add_visible_fileds_to_nova_blog_category.php
+++ b/database/migrations/2019_10_04_163805_add_visible_fileds_to_nova_blog_category.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddVisibleFiledsToNovaBlogCategory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $table = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($table, function (Blueprint $table) {
+            $table->boolean('visible')->default(1);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableCategory = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($tableCategory, function (Blueprint $table) {
+            $table->dropColumn('visible');
+            //
+        });
+    }
+}

--- a/database/migrations/2019_10_04_164208_add_parent_id_fileds_to_nova_blog_category.php
+++ b/database/migrations/2019_10_04_164208_add_parent_id_fileds_to_nova_blog_category.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Nova\Fields\Number;
+
+class AddParentIdFiledsToNovaBlogCategory extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $tableCategory = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($tableCategory, function (Blueprint $table) use ($tableCategory) {
+            $table->bigInteger('parent_id')->unsigned()->nullable();
+            $table->foreign('parent_id')->references('id')->on($tableCategory);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $tableCategory = config('nova-blog.table_categories', 'nova_blog_categories');
+        Schema::table($tableCategory, function (Blueprint $table) {
+            $table->dropForeign('parent_id');
+            $table->dropColumn('parent_id');
+        });
+    }
+}

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -3,8 +3,13 @@
 namespace OptimistDigital\NovaBlog\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use OptimistDigital\NovaBlog\NovaBlog;
 
 class Category extends Model
 {
-    //
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->setTable(NovaBlog::getCategoriesTableName());
+    }
 }

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -12,4 +12,8 @@ class Category extends Model
         parent::__construct($attributes);
         $this->setTable(NovaBlog::getCategoriesTableName());
     }
+
+    public function parent() {
+        return $this->belongsTo(self::class, 'parent_id', 'id');
+    }
 }

--- a/src/Nova/Category.php
+++ b/src/Nova/Category.php
@@ -2,12 +2,25 @@
 
 namespace OptimistDigital\NovaBlog\Nova;
 
+use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
+use Laravel\Nova\Fields\Heading;
 use Laravel\Nova\Fields\ID;
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Image;
+use Laravel\Nova\Fields\Number;
+use Laravel\Nova\Fields\Select;
+use Laravel\Nova\Fields\Textarea;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Laravel\Nova\Fields\Text;
+use Laravel\Nova\Panel;
 use OptimistDigital\NovaBlog\Nova\Fields\Slug;
 
+/**
+ * Class Category
+ * @package OptimistDigital\NovaBlog\Nova
+ * @property \OptimistDigital\NovaBlog\Models\Category $resource
+ */
 class Category extends TemplateResource
 {
 
@@ -43,11 +56,22 @@ class Category extends TemplateResource
      */
     public function fields(Request $request)
     {
-        return [
+
+        $fields = [
             ID::make()->sortable(),
             Text::make('Title', 'title'),
+            BelongsTo::make('parent', 'parent', self::class)->exceptOnForms(),
+            Select::make('Parent', 'parent_id')->options(\OptimistDigital\NovaBlog\Models\Category::where('id', '!=', $this->resource->id)->get()->pluck('title', 'id'))->onlyOnForms(),
+            Number::make('Sort', 'sort'),
             Slug::make('Slug', 'slug'),
+            Boolean::make('Visible?', 'visible'),
+            TextArea::make('Category introduction', 'category_introduction'),
+            TextArea::make('Category content', 'category_content'),
         ];
+
+        $fields[] = new Panel('SEO', $this->getSeoFields());
+        return $fields;
+
     }
 
     /**
@@ -92,5 +116,15 @@ class Category extends TemplateResource
     public function actions(Request $request)
     {
         return [];
+    }
+
+    protected function getSeoFields()
+    {
+        return [
+            Heading::make('SEO'),
+            Text::make('SEO Title', 'seo_title')->hideFromIndex(),
+            Text::make('SEO Description', 'seo_description')->hideFromIndex(),
+            Image::make('SEO Image', 'seo_image')->hideFromIndex(),
+        ];
     }
 }

--- a/src/NovaBlog.php
+++ b/src/NovaBlog.php
@@ -40,4 +40,10 @@ class NovaBlog extends Tool
     {
         return config('nova-blog.table', 'nova_blog');
     }
+
+
+    public static function getCategoriesTableName(): string
+    {
+        return config('nova-blog.table_categories', 'nova_blog_categories');
+    }
 }


### PR DESCRIPTION
In your project blog categories table not configurable. I added this to config. Tested it. And has fixed down migration in

`Schema::table('nova_blog_posts', function (Blueprint $table) {`
to configurable value
`$table = config('nova-blog.table', 'nova_blog_posts');
Schema::table($table, function (Blueprint $table) {`

Thanks for a great project!